### PR TITLE
Collect distributed coverage before stopping peers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,22 @@ defmodule Group.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       test_ignore_filters: [~r"^test/jepsen/", ~r"^test/mutation/"],
       start_permanent: Mix.env() == :prod,
+      test_coverage: [
+        local_only: false,
+        ignore_modules: [
+          Group.TestCluster,
+          Group.TestConflictResolver,
+          Group.TestReplicaTransport,
+          Group.TestTCPTransport,
+          Group.TestTCPTransport.Supervisor,
+          Group.ControlledReplicaTransport,
+          Group.CyclicConflictResolver,
+          Group.ModelConflictResolver,
+          Group.PausingConflictResolver,
+          Group.ReplicaLifecycleModel,
+          Group.ReplicaModelScheduler
+        ]
+      ],
       deps: deps(),
       aliases: aliases(),
       package: package(),

--- a/test/README.md
+++ b/test/README.md
@@ -20,6 +20,22 @@ runs the distribution/TCP/chaos × mixed/permanent Jepsen campaign. The soak
 defaults to 20 five-minute fault histories per combination and is intended for
 nightly and release qualification rather than individual edits.
 
+### Distributed coverage
+
+`mix test --cover` includes execution on the peer nodes. Mix coverage runs with
+`local_only: false`; `TestCluster.start_peers/2` loads the coordinator's
+instrumented modules on each peer before starting Group. This also keeps
+anonymous functions in the compiled support module compatible across nodes.
+Support modules are excluded from the coverage score.
+
+Always stop peers through `TestCluster.stop_peer({pid, node})` or
+`TestCluster.stop_peers(peers)`, including node-failure scenarios. These helpers
+collect remote coverage before shutting down the VM. An abrupt VM crash can
+still lose counters that have not been collected.
+
+`coverage_test.exs` checks that a peer-only call remains in the coordinator's
+coverage results after the peer stops. It is skipped without `--cover`.
+
 ## Test files
 
 | File | What it tests |

--- a/test/coverage_test.exs
+++ b/test/coverage_test.exs
@@ -1,0 +1,28 @@
+defmodule Group.CoverageTest do
+  use ExUnit.Case
+
+  alias Group.TestCluster
+
+  @tag skip: is_nil(Process.whereis(:cover_server))
+  test "peer-only execution is retained after the peer stops" do
+    before_calls = log_level_calls()
+    peers = TestCluster.start_peers(1)
+    on_exit(fn -> TestCluster.stop_peers(peers) end)
+    [{_, node} = peer] = peers
+    name = :coverage_peer
+
+    assert :cover_compiled = TestCluster.rpc!(node, :code, :which, [Group])
+    TestCluster.start_group(node, name: name, shards: 1)
+    TestCluster.rpc!(node, Group, :log_level, [name, false])
+    TestCluster.stop_peer(peer)
+
+    TestCluster.assert_eventually(fn -> node not in :cover.which_nodes() end)
+    assert log_level_calls() == before_calls + 1
+  end
+
+  defp log_level_calls do
+    {:ok, calls} = :cover.analyse(Group, :calls, :function)
+    {{Group, :log_level, 2}, count} = List.keyfind(calls, {Group, :log_level, 2}, 0)
+    count
+  end
+end

--- a/test/distributed_test.exs
+++ b/test/distributed_test.exs
@@ -234,7 +234,7 @@ defmodule Group.DistributedTest do
       end)
 
       # Stop node B
-      :peer.stop(peer_b_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
 
       # Node A should clean up B's entries
       TestCluster.assert_eventually(
@@ -248,7 +248,7 @@ defmodule Group.DistributedTest do
 
       # Clean up remaining peer
       [{peer_a_pid, _}] = Enum.filter(peers, fn {_, n} -> n == node_a end)
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
 
     test "process DOWN cleanup arrives as one remote batch per dead pid" do
@@ -789,8 +789,8 @@ defmodule Group.DistributedTest do
       end)
 
       # Stop B and C simultaneously
-      :peer.stop(peer_b_pid)
-      :peer.stop(peer_c_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
+      TestCluster.stop_peer({peer_c_pid, node_c})
 
       # A should clean up all of B's and C's entries
       TestCluster.assert_eventually(
@@ -805,7 +805,7 @@ defmodule Group.DistributedTest do
       # A's own data should be intact
       assert TestCluster.rpc!(node_a, Group, :lookup, [name, "user/a"]) != nil
 
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
   end
 
@@ -1373,7 +1373,7 @@ defmodule Group.DistributedTest do
       assert TestCluster.rpc!(node_a, Group, :lookup, [name, "nil_key"]) != nil
 
       # Now B crashes
-      :peer.stop(peer_b_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
 
       # A should clean up nil_key too
       TestCluster.assert_eventually(
@@ -1384,7 +1384,7 @@ defmodule Group.DistributedTest do
       )
 
       [{peer_a_pid, _}] = Enum.filter(peers, fn {_, n} -> n == node_a end)
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
 
     test "empty cluster removed on last disconnect" do
@@ -1597,7 +1597,7 @@ defmodule Group.DistributedTest do
       end)
 
       # Stop B
-      :peer.stop(peer_b_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
 
       # A should no longer see B
       TestCluster.assert_eventually(
@@ -1609,7 +1609,7 @@ defmodule Group.DistributedTest do
       )
 
       [{peer_a_pid, _}] = Enum.filter(peers, fn {_, n} -> n == node_a end)
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
   end
 
@@ -2140,7 +2140,7 @@ defmodule Group.DistributedTest do
       end)
 
       # Stop node A
-      :peer.stop(peer_a_pid)
+      TestCluster.stop_peer({peer_a_pid, node_a})
 
       # B should have cleaned up A's entries
       TestCluster.assert_eventually(fn ->
@@ -2163,7 +2163,7 @@ defmodule Group.DistributedTest do
         TestCluster.stop_peers([{new_a_pid, new_node_a}])
         # Stop remaining original peer B
         [{peer_b_pid, _}] = Enum.filter(peers, fn {_, n} -> n == node_b end)
-        :peer.stop(peer_b_pid)
+        TestCluster.stop_peer({peer_b_pid, node_b})
       end)
     end
   end
@@ -3105,7 +3105,7 @@ defmodule Group.DistributedTest do
       )
 
       # Kill node B
-      :peer.stop(peer_b_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
 
       # Wait for nodedown cleanup
       TestCluster.assert_eventually(
@@ -3161,7 +3161,7 @@ defmodule Group.DistributedTest do
         end
       end
 
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
 
     @tag timeout: 60_000
@@ -3370,7 +3370,7 @@ defmodule Group.DistributedTest do
       end)
 
       # Then B dies entirely
-      :peer.stop(peer_b_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
 
       # A should clean up everything — both the cluster disconnect and nodedown
       TestCluster.assert_eventually(
@@ -3408,7 +3408,7 @@ defmodule Group.DistributedTest do
         end
       end
 
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
   end
 
@@ -3514,7 +3514,7 @@ defmodule Group.DistributedTest do
       end)
 
       # Kill B
-      :peer.stop(peer_b_pid)
+      TestCluster.stop_peer({peer_b_pid, node_b})
 
       # A should not have B in any cluster_nodes — nil or named
       TestCluster.assert_eventually(
@@ -3547,7 +3547,7 @@ defmodule Group.DistributedTest do
       TestCluster.flush_shards(node_a, name)
       assert :ok = TestCluster.rpc!(node_a, Group.TestCluster, :assert_ets_consistent, [name])
 
-      on_exit(fn -> :peer.stop(peer_a_pid) end)
+      on_exit(fn -> TestCluster.stop_peer({peer_a_pid, node_a}) end)
     end
   end
 
@@ -3669,7 +3669,7 @@ defmodule Group.DistributedTest do
       assert_receive {:monitor_ready, ^forwarder}, 1000
 
       # Kill node_b — nodedown triggers bulk purge
-      :peer.stop(peer_b)
+      TestCluster.stop_peer({peer_b, node_b})
 
       # All 3 :unregistered events should arrive in a single batch
       # (they're on the same shard, processed in one nodedown handler turn)

--- a/test/support/test_cluster.ex
+++ b/test/support/test_cluster.ex
@@ -1,5 +1,7 @@
 defmodule Group.TestCluster do
   @moduledoc false
+  # Mix loads OTP's optional :tools application when --cover is requested.
+  @compile {:no_warn_undefined, :cover}
 
   @doc "Start N peer nodes with Group app loaded and ready"
   def start_peers(count, opts \\ []) do
@@ -36,6 +38,13 @@ defmodule Group.TestCluster do
           env: [{~c"ERL_AFLAGS", ~c""}]
         })
 
+      # Load the same instrumented BEAMs before any Group or helper code runs.
+      # Besides collecting remote execution, this keeps anonymous RPC functions
+      # compatible with the coordinator's cover-compiled helper module.
+      if Process.whereis(:cover_server) do
+        {:ok, [^node]} = :cover.start([node])
+      end
+
       {:ok, _} = :rpc.call(node, :application, :ensure_all_started, [:elixir])
       {:ok, _} = :rpc.call(node, :application, :ensure_all_started, [:group])
       {pid, node}
@@ -43,15 +52,22 @@ defmodule Group.TestCluster do
   end
 
   def stop_peers(peers) do
-    Enum.each(peers, fn {pid, _node} ->
-      if pid do
-        try do
-          :peer.stop(pid)
-        catch
-          :exit, _ -> :ok
-        end
-      end
-    end)
+    Enum.each(peers, &stop_peer/1)
+  end
+
+  @doc "Collects remote coverage before stopping a peer, including deliberate node failures."
+  def stop_peer({pid, node}) do
+    if Process.whereis(:cover_server) && node in :cover.which_nodes() do
+      # Collect without unloading instrumented code in a still-running Group.
+      # Reloading here can interfere with code-version and restart scenarios.
+      :ok = :cover.flush([node])
+    end
+
+    if pid && Process.alive?(pid) do
+      :peer.stop(pid)
+    end
+
+    :ok
   end
 
   @doc false


### PR DESCRIPTION
## Problem

Coverage instrumentation changes the coordinator's compiled helper functions, but distributed peers load ordinary BEAM files. This causes remote `badfun` failures under `mix test --cover`. Peer execution is also absent from the report unless its counters are collected before the VM stops.

## Fix

Enable distributed OTP coverage and attach each peer before starting Group. OTP loads the same instrumented modules on the peers, preserving anonymous-function compatibility and collecting their execution.

Route all peer shutdowns, including deliberate node-failure scenarios, through a coverage-aware helper that transfers counters before stopping the VM. Exclude support modules from the reported score and add a regression that checks retention of a peer-only call after shutdown.

## Supporting information

The combined coverage report is approximately 84.7%, below Mix's unchanged default 90% threshold. Consequently, `mix test --cover` still exits nonzero for the coverage threshold, rather than remote execution failures. This change does not lower the threshold or conceal the coverage gap.

Abrupt VM crashes can still lose counters not yet collected; the deliberate shutdown helper collects them first.
