### PR TITLE
Own benchmark workers and reject invalid results

### DIFF
--- a/priv/bench/README.md
+++ b/priv/bench/README.md
@@ -34,6 +34,28 @@ lookup behavior as that dynamic ETS table grows without requiring one million
 live BEAM processes. The normal join/leave and recovery scenarios measure the
 write and rebuild costs through real Group paths.
 
+Each local scenario owns a worker supervisor and stops every worker before the
+next scenario starts, including on failure. Operations must return `:ok`;
+worker exits and timeouts abort the run. Registry and membership datasets are
+checked before results are reported, and each read sample is validated outside
+its measured interval.
+
+Write workers are provisioned before timing begins. The write interval covers
+releasing the workers and waiting for successful operations, not process or
+worker-supervisor startup. Event delivery additionally includes validating the
+exact registration events (key, PID, metadata, cluster, and type); missing,
+unexpected, or duplicate events invalidate the result.
+
+These timing boundaries and scenario isolation differ from earlier versions.
+Establish a fresh baseline rather than comparing directly to old throughput
+numbers.
+
+The local harness has its own regression suite. From `priv/bench`, run:
+
+```bash
+mix test
+```
+
 ### Distributed benchmarks
 
 Uses 3 separate BEAM VMs (coordinator + 2 replicas) as OS processes:
@@ -109,8 +131,8 @@ Slower than lookup because each call copies a 100-element list out of ETS.
 
 ### 3. Register throughput (shard scaling)
 
-Measures concurrent `Group.register/4` calls — each of 10K spawned processes
-registers itself in parallel. Uses the library default of 8 shards for the
+Measures concurrent `Group.register/4` calls — each of 10K pre-provisioned
+workers registers itself. Uses the library default of 8 shards for the
 non-scaling scenarios and a fixed 1, 2, 4, 8, 16, 32, 64 shard sweep. The
 fixed sweep keeps results comparable across machines and avoids treating BEAM
 scheduler count as a shard-count recommendation.
@@ -124,8 +146,8 @@ Reports per-cycle latency percentiles.
 
 ### 5. Join throughput (shard scaling)
 
-Same shape as register throughput but with `Group.join/4`. 10K processes each
-join a group concurrently, varying shard count.
+Same shape as register throughput but with `Group.join/4`. 10K pre-provisioned
+workers each join a group concurrently, varying shard count.
 
 ### 6. Join/leave cycle
 
@@ -135,7 +157,8 @@ quantifies the materialized counter write amplification on the public API path.
 ### 7. Monitor event delivery
 
 Calls `Group.monitor(:bench, :all)`, then registers 5K keys and measures the
-time until all 5K `:registered` events are received by the monitoring process.
+time until all 5K `:registered` events are received and validated by the
+monitoring process.
 
 ## Distributed Scenarios
 

--- a/priv/bench/lib/group_bench/helpers.ex
+++ b/priv/bench/lib/group_bench/helpers.ex
@@ -12,11 +12,13 @@ defmodule GroupBench.Helpers do
 
   @doc """
   Collects N timing samples by calling `fun` repeatedly.
+  Validates each result outside its measured interval.
   Returns a sorted list of microsecond timings.
   """
-  def collect_samples(n, fun) do
+  def collect_samples(n, fun, validate \\ fn _ -> :ok end) do
     Enum.map(1..n, fn _ ->
-      {us, _} = :timer.tc(fun)
+      {us, result} = :timer.tc(fun)
+      :ok = validate.(result)
       us
     end)
     |> Enum.sort()
@@ -131,56 +133,180 @@ defmodule GroupBench.Helpers do
   end
 
   @doc """
-  Starts a fresh Group instance with the given options, runs `fun`, then stops it.
+  Runs `fun` with a scenario-owned worker supervisor and a fresh Group instance.
+  Both supervisors are stopped synchronously, even when the scenario raises.
   """
   def with_group(opts, fun) do
     opts = Keyword.put_new(opts, :name, :bench)
-    old_trap = Process.flag(:trap_exit, true)
-    {:ok, sup} = Group.start_link(opts)
+    opts = Keyword.put_new(opts, :log, false)
+    {:ok, workers} = Task.Supervisor.start_link()
 
     try do
-      fun.()
-    after
-      Process.unlink(sup)
+      {:ok, sup} = Group.start_link(opts)
 
       try do
-        Supervisor.stop(sup, :shutdown, 5_000)
-      catch
-        :exit, _ -> :ok
+        fun.(workers)
+      after
+        # Registry links subscribers to its partition. Remove this scenario's
+        # subscriptions before shutdown instead of trapping and discarding exits.
+        registry = Group.registry_name(Keyword.fetch!(opts, :name))
+        Enum.each(Registry.keys(registry, self()), &Registry.unregister(registry, &1))
+        Supervisor.stop(sup)
       end
-
-      # Drain any EXIT messages from the stopped supervisor / children
-      drain_exits()
-
-      Process.flag(:trap_exit, old_trap)
-      Process.sleep(50)
-    end
-  end
-
-  defp drain_exits do
-    receive do
-      {:EXIT, _, _} -> drain_exits()
     after
-      0 -> :ok
+      Supervisor.stop(workers)
     end
   end
 
   @doc """
-  Spawns N long-lived processes that stay alive until the caller exits.
-  Returns a list of pids.
+  Provisions N workers, then times releasing them and waiting for successful ops.
+
+  Workers stay alive until the scenario supervisor stops. Provisioning is outside
+  the timed interval, so the worker supervisor is not a throughput bottleneck.
+  `after_ready` optionally waits for event delivery within the same interval.
+  Returns `{microseconds, pids}`.
   """
-  def spawn_processes(n) do
+  def run_workers(supervisor, n, operation, after_ready \\ fn _ -> :ok end, timeout \\ 10_000)
+      when n > 0 do
     parent = self()
+    ref = make_ref()
 
-    Enum.map(1..n, fn _ ->
-      spawn(fn ->
-        ref = Process.monitor(parent)
+    workers =
+      for i <- 1..n do
+        {:ok, pid} =
+          Task.Supervisor.start_child(supervisor, fn ->
+            receive do
+              {:run, ^ref} ->
+                result = operation.(i)
+                send(parent, {ref, self(), result})
+                Process.sleep(:infinity)
+            end
+          end)
 
-        receive do
-          {:DOWN, ^ref, _, _, _} -> :ok
+        {pid, Process.monitor(pid)}
+      end
+
+    pids = Enum.map(workers, &elem(&1, 0))
+    monitors = Map.new(workers)
+
+    try do
+      {us, _} =
+        time_us(fn ->
+          deadline = System.monotonic_time(:millisecond) + timeout
+          Enum.each(pids, &send(&1, {:run, ref}))
+          await_workers(monitors, monitors, ref, deadline)
+          :ok = after_ready.(pids)
+        end)
+
+      {us, pids}
+    after
+      Enum.each(workers, fn {_pid, monitor} -> Process.demonitor(monitor, [:flush]) end)
+    end
+  end
+
+  defp await_workers(pending, _monitors, _ref, _deadline) when map_size(pending) == 0, do: :ok
+
+  defp await_workers(pending, monitors, ref, deadline) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {^ref, pid, :ok} when is_map_key(pending, pid) ->
+        await_workers(Map.delete(pending, pid), monitors, ref, deadline)
+
+      {^ref, pid, result} when is_map_key(pending, pid) ->
+        raise "benchmark worker #{inspect(pid)} returned #{inspect(result)}, expected :ok"
+
+      {:DOWN, monitor, :process, pid, reason}
+      when is_map_key(monitors, pid) and :erlang.map_get(pid, monitors) == monitor ->
+        raise "benchmark worker #{inspect(pid)} exited: #{inspect(reason)}"
+    after
+      remaining -> raise "timed out waiting for #{map_size(pending)} benchmark workers"
+    end
+  end
+
+  @doc "Checks the exact registry dataset before reporting a benchmark result."
+  def verify_registry(name, entries, opts \\ []) do
+    count = Group.local_registry_count(name, opts)
+
+    if count != length(entries) do
+      raise "unexpected registry count: expected #{length(entries)}, got #{count}"
+    end
+
+    for {key, pid, meta} <- entries do
+      unless Group.lookup(name, key, opts) == {pid, meta} do
+        raise "unexpected registration for #{inspect(key)}"
+      end
+    end
+
+    :ok
+  end
+
+  @doc "Checks exact group membership, including metadata and duplicate entries."
+  def verify_members(name, entries, opts \\ []) do
+    for {key, expected} <-
+          Enum.group_by(entries, &elem(&1, 0), fn {_, pid, meta} -> {pid, meta} end) do
+      unless Enum.sort(Group.members(name, key, opts)) == Enum.sort(expected) do
+        raise "unexpected memberships for #{inspect(key)}"
+      end
+    end
+
+    :ok
+  end
+
+  @doc "Requires exactly the expected registration events, with a bounded total wait."
+  def await_registered_events(name, cluster, entries, timeout \\ 5_000) do
+    pending = MapSet.new(entries)
+
+    if MapSet.size(pending) != length(entries) do
+      raise "duplicate expected registration events"
+    end
+
+    deadline = System.monotonic_time(:millisecond) + timeout
+    receive_registered_events(name, cluster, pending, deadline)
+  end
+
+  defp receive_registered_events(name, cluster, pending, deadline) do
+    timeout =
+      if MapSet.size(pending) == 0,
+        do: 0,
+        else: max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:group, events, %{name: ^name}} ->
+        pending =
+          Enum.reduce(events, pending, fn
+            %Group.Event{
+              supervisor: ^name,
+              cluster: ^cluster,
+              type: :registered,
+              previous_meta: nil,
+              reason: nil,
+              key: key,
+              pid: pid,
+              meta: meta
+            } = event,
+            pending ->
+              entry = {key, pid, meta}
+
+              unless MapSet.member?(pending, entry) do
+                raise "unexpected or duplicate registration event: #{inspect(event)}"
+              end
+
+              MapSet.delete(pending, entry)
+
+            event, _pending ->
+              raise "unexpected registration event: #{inspect(event)}"
+          end)
+
+        receive_registered_events(name, cluster, pending, deadline)
+    after
+      timeout ->
+        if MapSet.size(pending) != 0 do
+          raise "timed out waiting for #{MapSet.size(pending)} registration events"
         end
-      end)
-    end)
+
+        :ok
+    end
   end
 
   @doc """

--- a/priv/bench/lib/group_bench/local.ex
+++ b/priv/bench/lib/group_bench/local.ex
@@ -36,7 +36,7 @@ defmodule GroupBench.Local do
     IO.puts("  samples/query:     #{format_number(samples)}")
 
     Enum.each([1_000, 100_000, 1_000_000], fn cardinality ->
-      with_group([name: @name, shards: shards], fn ->
+      with_group([name: @name, shards: shards], fn _workers ->
         subheader("#{format_number(cardinality)} distinct membership keys")
         {seed_us, :ok} = time_us(fn -> seed_member_count_index(cardinality, shards) end)
 
@@ -57,11 +57,19 @@ defmodule GroupBench.Local do
         IO.puts("  count-index memory: #{Float.round(memory_bytes / 1_048_576, 1)} MiB")
 
         warmup(1_000, fn -> Group.member_count(@name, exact_key) end)
-        exact_samples = collect_samples(samples, fn -> Group.member_count(@name, exact_key) end)
+
+        exact_samples =
+          collect_samples(samples, fn -> Group.member_count(@name, exact_key) end, fn 1 -> :ok end)
+
         report_latency("exact Group.member_count/3", exact_samples)
 
         warmup(1_000, fn -> Group.member_count(@name, prefix) end)
-        prefix_samples = collect_samples(samples, fn -> Group.member_count(@name, prefix) end)
+
+        prefix_samples =
+          collect_samples(samples, fn -> Group.member_count(@name, prefix) end, fn ^cardinality ->
+            :ok
+          end)
+
         report_latency("prefix Group.member_count/3", prefix_samples)
       end)
     end)
@@ -77,32 +85,42 @@ defmodule GroupBench.Local do
     for {cluster_label, cluster_opt} <- clusters() do
       subheader("cluster: #{cluster_label}")
 
-      with_group([name: @name, shards: @default_shards], fn ->
+      with_group([name: @name, shards: @default_shards], fn workers ->
         maybe_connect_cluster(cluster_opt)
         key_count = 10_000
         measure_count = 100_000
 
         # Each process registers itself
-        pids =
-          register_from_spawned_processes(key_count, fn i ->
+        {_, pids} =
+          run_workers(workers, key_count, fn i ->
             Group.register(@name, "key-#{i}", %{i: i}, cluster_opts(cluster_opt))
           end)
 
-        try do
-          # warmup
-          warmup(1_000, fn -> Group.lookup(@name, "key-1", cluster_opts(cluster_opt)) end)
+        entries = indexed_entries(pids, &"key-#{&1}", &%{i: &1})
+        verify_registry(@name, entries, cluster_opts(cluster_opt))
+        expected = entries |> Enum.map(fn {_, pid, meta} -> {pid, meta} end) |> List.to_tuple()
 
-          # measure
-          samples =
-            collect_samples(measure_count, fn ->
+        # warmup
+        warmup(1_000, fn -> Group.lookup(@name, "key-1", cluster_opts(cluster_opt)) end)
+
+        # measure
+        samples =
+          collect_samples(
+            measure_count,
+            fn ->
               i = :rand.uniform(key_count)
-              Group.lookup(@name, "key-#{i}", cluster_opts(cluster_opt))
-            end)
+              {i, Group.lookup(@name, "key-#{i}", cluster_opts(cluster_opt))}
+            end,
+            fn {i, actual} ->
+              if actual != elem(expected, i - 1),
+                do: raise("incorrect lookup sample for key-#{i}")
 
-          report_latency("Group.lookup/3", samples)
-        after
-          stop_spawned_processes(pids)
-        end
+              :ok
+            end
+          )
+
+        verify_registry(@name, entries, cluster_opts(cluster_opt))
+        report_latency("Group.lookup/3", samples)
       end)
     end
   end
@@ -115,7 +133,7 @@ defmodule GroupBench.Local do
     for {cluster_label, cluster_opt} <- clusters() do
       subheader("cluster: #{cluster_label}")
 
-      with_group([name: @name, shards: @default_shards], fn ->
+      with_group([name: @name, shards: @default_shards], fn workers ->
         maybe_connect_cluster(cluster_opt)
         group_count = 100
         members_per_group = 100
@@ -124,25 +142,40 @@ defmodule GroupBench.Local do
         total = group_count * members_per_group
 
         # Each process joins a group
-        pids =
-          register_from_spawned_processes(total, fn i ->
-            gi = rem(i - 1, group_count) + 1
-            Group.join(@name, "group-#{gi}", %{}, cluster_opts(cluster_opt))
+        group_key = fn i -> "group-#{rem(i - 1, group_count) + 1}" end
+
+        {_, pids} =
+          run_workers(workers, total, fn i ->
+            Group.join(@name, group_key.(i), %{}, cluster_opts(cluster_opt))
           end)
 
-        try do
-          warmup(1_000, fn -> Group.members(@name, "group-1", cluster_opts(cluster_opt)) end)
+        entries = indexed_entries(pids, group_key, fn _ -> %{} end)
+        verify_members(@name, entries, cluster_opts(cluster_opt))
 
-          samples =
-            collect_samples(measure_count, fn ->
-              gi = :rand.uniform(group_count)
-              Group.members(@name, "group-#{gi}", cluster_opts(cluster_opt))
-            end)
+        expected =
+          entries
+          |> Enum.group_by(&elem(&1, 0), fn {_, pid, meta} -> {pid, meta} end)
+          |> Map.new(fn {key, members} -> {key, Enum.sort(members)} end)
 
-          report_latency("Group.members/3", samples)
-        after
-          stop_spawned_processes(pids)
-        end
+        warmup(1_000, fn -> Group.members(@name, "group-1", cluster_opts(cluster_opt)) end)
+
+        samples =
+          collect_samples(
+            measure_count,
+            fn ->
+              key = "group-#{:rand.uniform(group_count)}"
+              {key, Group.members(@name, key, cluster_opts(cluster_opt))}
+            end,
+            fn {key, actual} ->
+              if Enum.sort(actual) != Map.fetch!(expected, key),
+                do: raise("incorrect members sample for #{key}")
+
+              :ok
+            end
+          )
+
+        verify_members(@name, entries, cluster_opts(cluster_opt))
+        report_latency("Group.members/3", samples)
       end)
     end
   end
@@ -158,21 +191,17 @@ defmodule GroupBench.Local do
       subheader("cluster: #{cluster_label}")
 
       for shards <- @shard_counts do
-        with_group([name: @name, shards: shards], fn ->
+        with_group([name: @name, shards: shards], fn workers ->
           maybe_connect_cluster(cluster_opt)
 
           {wall_us, pids} =
-            time_us(fn ->
-              register_from_spawned_processes(n, fn i ->
-                Group.register(@name, "reg-#{i}", %{}, cluster_opts(cluster_opt))
-              end)
+            run_workers(workers, n, fn i ->
+              Group.register(@name, "reg-#{i}", %{}, cluster_opts(cluster_opt))
             end)
 
-          try do
-            report_throughput("shards=#{shards}", n, wall_us)
-          after
-            stop_spawned_processes(pids)
-          end
+          entries = indexed_entries(pids, &"reg-#{&1}", fn _ -> %{} end)
+          verify_registry(@name, entries, cluster_opts(cluster_opt))
+          report_throughput("shards=#{shards}", n, wall_us)
         end)
       end
     end
@@ -188,7 +217,7 @@ defmodule GroupBench.Local do
     for {cluster_label, cluster_opt} <- clusters() do
       subheader("cluster: #{cluster_label}")
 
-      with_group([name: @name, shards: @default_shards], fn ->
+      with_group([name: @name, shards: @default_shards], fn _workers ->
         maybe_connect_cluster(cluster_opt)
         opts = cluster_opts(cluster_opt)
 
@@ -200,6 +229,7 @@ defmodule GroupBench.Local do
             :ok = Group.unregister(@name, key, opts)
           end)
 
+        verify_registry(@name, [], opts)
         report_latency("register+unregister", samples)
       end)
     end
@@ -216,21 +246,18 @@ defmodule GroupBench.Local do
       subheader("cluster: #{cluster_label}")
 
       for shards <- @shard_counts do
-        with_group([name: @name, shards: shards], fn ->
+        with_group([name: @name, shards: shards], fn workers ->
           maybe_connect_cluster(cluster_opt)
+          group_key = fn i -> "join-group-#{rem(i, 100)}" end
 
           {wall_us, pids} =
-            time_us(fn ->
-              register_from_spawned_processes(n, fn i ->
-                Group.join(@name, "join-group-#{rem(i, 100)}", %{}, cluster_opts(cluster_opt))
-              end)
+            run_workers(workers, n, fn i ->
+              Group.join(@name, group_key.(i), %{}, cluster_opts(cluster_opt))
             end)
 
-          try do
-            report_throughput("shards=#{shards}", n, wall_us)
-          after
-            stop_spawned_processes(pids)
-          end
+          entries = indexed_entries(pids, group_key, fn _ -> %{} end)
+          verify_members(@name, entries, cluster_opts(cluster_opt))
+          report_throughput("shards=#{shards}", n, wall_us)
         end)
       end
     end
@@ -246,7 +273,7 @@ defmodule GroupBench.Local do
     for {cluster_label, cluster_opt} <- clusters() do
       subheader("cluster: #{cluster_label}")
 
-      with_group([name: @name, shards: @default_shards], fn ->
+      with_group([name: @name, shards: @default_shards], fn _workers ->
         maybe_connect_cluster(cluster_opt)
         opts = cluster_opts(cluster_opt)
 
@@ -257,6 +284,7 @@ defmodule GroupBench.Local do
             :ok = Group.leave(@name, key, opts)
           end)
 
+        0 = Group.member_count(@name, "cycle/group/", opts)
         report_latency("join+leave (two slash-prefixes)", samples)
       end)
     end
@@ -272,28 +300,27 @@ defmodule GroupBench.Local do
     for {cluster_label, cluster_opt} <- clusters() do
       subheader("cluster: #{cluster_label}")
 
-      with_group([name: @name, shards: @default_shards], fn ->
+      with_group([name: @name, shards: @default_shards], fn workers ->
         maybe_connect_cluster(cluster_opt)
         :ok = Group.monitor(@name, :all, cluster_opts(cluster_opt))
         drain_stale_group_events()
 
         {wall_us, pids} =
-          time_us(fn ->
-            pids =
-              register_from_spawned_processes(n, fn i ->
-                Group.register(@name, "mon-#{i}", %{}, cluster_opts(cluster_opt))
-              end)
+          run_workers(
+            workers,
+            n,
+            fn i ->
+              Group.register(@name, "mon-#{i}", %{}, cluster_opts(cluster_opt))
+            end,
+            fn pids ->
+              entries = indexed_entries(pids, &"mon-#{&1}", fn _ -> %{} end)
+              await_registered_events(@name, cluster_opt, entries)
+            end
+          )
 
-            # drain all N events
-            drain_events(n)
-            pids
-          end)
-
-        try do
-          report_throughput("events (register → receive)", n, wall_us)
-        after
-          stop_spawned_processes(pids)
-        end
+        entries = indexed_entries(pids, &"mon-#{&1}", fn _ -> %{} end)
+        verify_registry(@name, entries, cluster_opts(cluster_opt))
+        report_throughput("events (register → validated receipt)", n, wall_us)
       end)
     end
   end
@@ -310,45 +337,11 @@ defmodule GroupBench.Local do
   defp cluster_opts(nil), do: []
   defp cluster_opts(cluster), do: [cluster: cluster]
 
-  @doc false
-  # Spawns N processes, each of which calls `fun.(index)` where index is 1..n.
-  # Processes stay alive after the call. Waits for all to complete.
-  defp register_from_spawned_processes(n, fun) do
-    parent = self()
-
-    pids =
-      Enum.map(1..n, fn i ->
-        spawn(fn ->
-          result = fun.(i)
-          send(parent, {:done, self(), result})
-
-          # Stay alive so the registration/membership persists
-          Process.sleep(:infinity)
-        end)
-      end)
-
-    # Wait for all to complete
-    Enum.each(pids, fn pid ->
-      receive do
-        {:done, ^pid, _result} -> :ok
-      after
-        10_000 -> raise "Timed out waiting for #{inspect(pid)}"
-      end
-    end)
-
+  defp indexed_entries(pids, key, meta) do
     pids
-  end
-
-  defp stop_spawned_processes(pids) do
-    refs = Enum.map(pids, &{&1, Process.monitor(&1)})
-    Enum.each(pids, &Process.exit(&1, :kill))
-
-    Enum.each(refs, fn {pid, ref} ->
-      receive do
-        {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
-      after
-        5_000 -> raise "Timed out stopping #{inspect(pid)}"
-      end
+    |> Enum.with_index(1)
+    |> Enum.map(fn {pid, i} ->
+      {key.(i), pid, meta.(i)}
     end)
   end
 
@@ -391,18 +384,6 @@ defmodule GroupBench.Local do
     end)
 
     :ok
-  end
-
-  defp drain_events(0), do: :ok
-
-  defp drain_events(remaining) do
-    receive do
-      {:group, events, _info} ->
-        count = Enum.count(events, &match?(%Group.Event{type: :registered}, &1))
-        drain_events(remaining - count)
-    after
-      5_000 -> IO.puts("    WARNING: timed out waiting for events, #{remaining} remaining")
-    end
   end
 
   defp drain_stale_group_events do

--- a/priv/bench/test/helpers_test.exs
+++ b/priv/bench/test/helpers_test.exs
@@ -1,0 +1,228 @@
+defmodule GroupBench.HelpersTest do
+  use ExUnit.Case, async: true
+
+  alias GroupBench.Helpers
+
+  @moduletag :capture_log
+
+  setup do
+    %{name: :"bench_test_#{System.unique_integer([:positive])}"}
+  end
+
+  test "workers retain valid entries during a scenario and all stop before it returns", %{
+    name: name
+  } do
+    {pool, pids} =
+      Helpers.with_group([name: name, shards: 2], fn pool ->
+        :ok = Group.monitor(name, :all)
+
+        {us, pids} =
+          Helpers.run_workers(
+            pool,
+            3,
+            fn i -> Group.register(name, "key-#{i}", %{i: i}) end,
+            fn pids ->
+              Helpers.await_registered_events(name, nil, entries(pids))
+            end
+          )
+
+        assert is_integer(us)
+        assert Enum.all?(pids, &Process.alive?/1)
+        assert :ok = Helpers.verify_registry(name, entries(pids))
+        {pool, pids}
+      end)
+
+    refute Process.alive?(pool)
+    refute Enum.any?(pids, &Process.alive?/1)
+  end
+
+  test "registry verification uses the selected cluster", %{name: name} do
+    Helpers.with_group([name: name, shards: 1], fn pool ->
+      :ok = Group.connect(name, "game")
+      :ok = Group.register(name, "default", %{})
+      :ok = Group.monitor(name, :all, cluster: "game")
+
+      {_, pids} =
+        Helpers.run_workers(
+          pool,
+          3,
+          fn i -> Group.register(name, "key-#{i}", %{i: i}, cluster: "game") end,
+          fn pids -> Helpers.await_registered_events(name, "game", entries(pids)) end
+        )
+
+      assert :ok = Helpers.verify_registry(name, entries(pids), cluster: "game")
+      assert :ok = Helpers.verify_registry(name, [{"default", self(), %{}}])
+    end)
+  end
+
+  test "a failed scenario also stops its workers", %{name: name} do
+    parent = self()
+
+    assert_raise RuntimeError, "scenario failed", fn ->
+      Helpers.with_group([name: name, shards: 1], fn pool ->
+        {_, pids} = Helpers.run_workers(pool, 3, fn _ -> :ok end)
+        send(parent, {:resources, pool, pids})
+        raise "scenario failed"
+      end)
+    end
+
+    assert_receive {:resources, pool, pids}
+    refute Process.alive?(pool)
+    refute Enum.any?(pids, &Process.alive?/1)
+  end
+
+  test "unsuccessful operations abort the scenario instead of counting as completed work", %{
+    name: name
+  } do
+    parent = self()
+
+    assert_raise RuntimeError, ~r/returned \{:error, :rejected\}, expected :ok/, fn ->
+      Helpers.with_group([name: name, shards: 1], fn pool ->
+        Helpers.run_workers(pool, 1, fn _ ->
+          send(parent, {:worker, self()})
+          {:error, :rejected}
+        end)
+      end)
+    end
+
+    assert_receive {:worker, pid}
+    refute Process.alive?(pid)
+  end
+
+  test "crashed operations fail without waiting for the completion timeout", %{name: name} do
+    assert_raise RuntimeError, ~r/exited: :broken/, fn ->
+      Helpers.with_group([name: name, shards: 1], fn pool ->
+        Helpers.run_workers(pool, 1, fn _ -> exit(:broken) end)
+      end)
+    end
+  end
+
+  test "timed-out workers are stopped", %{name: name} do
+    parent = self()
+
+    assert_raise RuntimeError, "timed out waiting for 1 benchmark workers", fn ->
+      Helpers.with_group([name: name, shards: 1], fn pool ->
+        send(parent, {:pool, pool})
+
+        Helpers.run_workers(
+          pool,
+          1,
+          fn _ -> Process.sleep(:infinity) end,
+          fn _ -> :ok end,
+          1
+        )
+      end)
+    end
+
+    assert_receive {:pool, pool}
+    refute Process.alive?(pool)
+  end
+
+  test "exact membership verification detects wrong metadata", %{name: name} do
+    Helpers.with_group([name: name, shards: 1], fn pool ->
+      {_, [pid]} = Helpers.run_workers(pool, 1, fn _ -> Group.join(name, "room", %{v: 1}) end)
+      assert :ok = Helpers.verify_members(name, [{"room", pid, %{v: 1}}])
+
+      assert_raise RuntimeError, ~r/unexpected memberships/, fn ->
+        Helpers.verify_members(name, [{"room", pid, %{v: 2}}])
+      end
+    end)
+  end
+
+  test "exact registry verification rejects a wrong owner even when the count matches", %{
+    name: name
+  } do
+    Helpers.with_group([name: name, shards: 1], fn pool ->
+      {_, [_pid]} = Helpers.run_workers(pool, 1, fn _ -> Group.register(name, "key", %{}) end)
+
+      assert_raise RuntimeError, ~r/unexpected registration/, fn ->
+        Helpers.verify_registry(name, [{"key", self(), %{}}])
+      end
+    end)
+  end
+
+  test "every timed sample must pass result validation" do
+    assert_raise RuntimeError, "invalid sample", fn ->
+      Helpers.collect_samples(1, fn -> :wrong end, fn
+        :ok -> :ok
+        _ -> raise "invalid sample"
+      end)
+    end
+
+    assert [sample] = Helpers.collect_samples(1, fn -> :ok end)
+    assert is_integer(sample)
+  end
+
+  test "missing registration events fail rather than returning a partial result", %{name: name} do
+    assert_raise RuntimeError, "timed out waiting for 1 registration events", fn ->
+      Helpers.await_registered_events(name, nil, [{"key", self(), %{}}], 1)
+    end
+  end
+
+  test "duplicate events cannot substitute for missing events", %{name: name} do
+    event = event(name)
+    send(self(), {:group, [event, event], %{name: name}})
+
+    assert_raise RuntimeError, ~r/duplicate registration event/, fn ->
+      Helpers.await_registered_events(name, nil, [{"key", self(), %{}}, {"other", self(), %{}}])
+    end
+  end
+
+  test "extra event batches are rejected even after every expected event arrived", %{name: name} do
+    event = event(name)
+    send(self(), {:group, [event], %{name: name}})
+    send(self(), {:group, [event], %{name: name}})
+
+    assert_raise RuntimeError, ~r/duplicate registration event/, fn ->
+      Helpers.await_registered_events(name, nil, [{"key", self(), %{}}])
+    end
+  end
+
+  for {field, value} <- [
+        key: "wrong",
+        pid: :wrong,
+        meta: %{wrong: true},
+        cluster: "wrong",
+        supervisor: :wrong,
+        type: :unregistered,
+        reason: :wrong,
+        previous_meta: %{}
+      ] do
+    @tag field: field, value: value
+    test "wrong #{field} invalidates registration events", %{
+      name: name,
+      field: field,
+      value: value
+    } do
+      send(self(), {:group, [Map.put(event(name), field, value)], %{name: name}})
+
+      assert_raise RuntimeError, ~r/unexpected/, fn ->
+        Helpers.await_registered_events(name, nil, [{"key", self(), %{}}])
+      end
+    end
+  end
+
+  test "named-cluster events may arrive in any batch order", %{name: name} do
+    first = %{event(name) | cluster: "game"}
+    second = %{first | key: "other"}
+    send(self(), {:group, [second], %{name: name}})
+    send(self(), {:group, [first], %{name: name}})
+
+    assert :ok =
+             Helpers.await_registered_events(
+               name,
+               "game",
+               [{"key", self(), %{}}, {"other", self(), %{}}]
+             )
+  end
+
+  defp entries(pids) do
+    pids
+    |> Enum.with_index(1)
+    |> Enum.map(fn {pid, i} -> {"key-#{i}", pid, %{i: i}} end)
+  end
+
+  defp event(name) do
+    %Group.Event{supervisor: name, type: :registered, key: "key", pid: self(), meta: %{}}
+  end
+end

--- a/priv/bench/test/test_helper.exs
+++ b/priv/bench/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
## Problem

Local benchmark workers sleep forever without a scenario owner. Stopping Group does not stop those workers, so later scenarios inherit an increasingly large process population. Operation results are ignored, and event-delivery timeouts merely print a warning before reporting throughput for all expected events.

## Fix

Give each scenario a worker supervisor and synchronously stop its workers on success or failure. Provision workers before releasing the measured workload so supervisor startup does not become a serial throughput bottleneck.

Require successful operation results, detect worker exits and timeouts, verify registry and membership datasets, and validate each read sample outside its timed interval. Event delivery requires the exact expected registrations, rejecting missing, duplicate, or incorrect events instead of reporting partial work as success.

Add a standalone harness regression suite covering resource ownership, failure paths, cluster-scoped verification, and event validation. Remove monitor subscriptions before teardown so Registry shutdown does not require swallowing exit signals.

## Supporting information

Write timings now exclude worker provisioning; event timings include exact event validation. Existing throughput figures are not directly comparable: establish a fresh baseline with the corrected harness.

This change affects the local benchmark harness only. It adds no runtime dependencies and does not change Group's production implementation.
