### PR TITLE
Check cluster isolation through buffered replication and reconnects

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -16,7 +16,7 @@ mix test test/distributed_test.exs # distributed only
 |------|---------------|
 | `group_test.exs` | Single-node: register/unregister, join/leave, members, monitor/demonitor, named clusters, concurrent operations |
 | `group_property_test.exs` | StreamData local command histories checked against an independent map/set model |
-| `replication_property_test.exs` | Generated receiver batch boundaries checked against a map-based oracle |
+| `replication_property_test.exs` | Generated receiver batch boundaries and buffered/snapshot cluster isolation |
 | `distributed_test.exs` | Multi-node: replication, peer discovery, node disconnect cleanup, partition healing, conflict resolution, event ordering, rolling restarts |
 
 ## Local model properties
@@ -74,6 +74,11 @@ PropCheck/PropEr rather than implementing that framework here.
   buffer-plus-one, and whole-history messages. Each partition gets a fresh Group
   instance and is checked against a map-based oracle for contents and per-key
   event order, including metadata and removal reasons. Runs 100 examples per lane.
+- **Cluster isolation:** prove writes are pending in receiver buffers before
+  disconnecting. Neither flushing those buffers nor replaying batches/snapshots
+  may repopulate the disconnected cluster or emit transient apply-then-purge
+  events. Reconnect cycles must accept fresh snapshots while preserving entries
+  in the default and another named cluster. Runs 50 examples per lane.
 
 These are controlled receiver-protocol scenarios using real local owner PIDs;
 they do not traverse Erlang distribution or exercise sender batching. Registry

--- a/test/replication_property_test.exs
+++ b/test/replication_property_test.exs
@@ -45,6 +45,91 @@ defmodule Group.ReplicationPropertyTest do
         end
       end
     end
+
+    property "#{kind} buffers and snapshots cannot repopulate a cluster after disconnect" do
+      check all(
+              shards <- member_of([1, 2, 4]),
+              buffer <- member_of([2, 4, 8]),
+              count <- integer(1..(buffer - 1)),
+              value <- integer(0..10),
+              cycles <- integer(1..3),
+              max_runs: 50
+            ) do
+        with_group(@name, options(shards, buffer), fn actors ->
+          cluster = "shared"
+          assert :ok = Group.connect(@name, [cluster, "other"])
+
+          # Surviving entries use the same key in two other clusters.
+          for c <- [nil, "other"] do
+            in_process(actors[0], fn ->
+              :ok = Group.register(@name, "hot/a", %{survivor: true}, cluster: c)
+              :ok = Group.join(@name, "hot/a", %{survivor: true}, cluster: c)
+            end)
+          end
+
+          survivors = Enum.sort(Group.local_entries(@name))
+          subscribe(actors.observer, cluster)
+          commands = for i <- 0..(count - 1), do: {:put, rem(i, 4), rem(i, 2), value + i}
+
+          {ops, entries, _events} =
+            compile_history(unquote(kind), cluster, commands, actors)
+
+          deliver(unquote(kind), ops, 1, shards)
+
+          # System messages inspect without flushing the normal mailbox lane.
+          # Prove the operations really are buffered before membership is removed.
+          pending =
+            for shard <- 0..(shards - 1) do
+              state = :sys.get_state(Replica.shard_name(@name, shard))
+
+              case unquote(kind) do
+                :registry -> state.pending_replicated_registry_len
+                :pg -> state.pending_replicated_pg_len
+              end
+            end
+
+          assert Enum.sum(pending) == length(ops)
+          assert :ok = Group.disconnect(@name, cluster)
+          # Checking events catches an incorrect apply-then-purge, even if both
+          # indexes end up empty and therefore appear consistent.
+          assert events_after_barrier(@name, actors.observer) == []
+          assert Enum.sort(Group.local_entries(@name)) == survivors
+
+          for _cycle <- 1..cycles do
+            deliver(unquote(kind), ops, buffer + 1, shards)
+            snapshot(unquote(kind), cluster, entries, shards)
+            assert events_after_barrier(@name, actors.observer) == []
+            assert Enum.sort(Group.local_entries(@name)) == survivors
+            refute Group.connected?(@name, cluster)
+
+            assert :ok = Group.connect(@name, cluster)
+            snapshot(unquote(kind), cluster, entries, shards)
+            actual_events = events_after_barrier(@name, actors.observer)
+
+            # Snapshots contain only the final entry for each key/owner.
+            snapshot_events =
+              entries
+              |> Enum.map(fn {{key, pid}, meta} ->
+                event(unquote(kind), cluster, key, pid, meta, nil, nil)
+              end)
+
+            assert_per_key_events(actual_events, snapshot_events)
+            assert_entries(entries, unquote(kind), cluster, survivors)
+
+            assert :ok = Group.disconnect(@name, cluster)
+
+            removals =
+              Enum.map(snapshot_events, fn e ->
+                %{e | type: removal_type(unquote(kind)), reason: :cluster_disconnect}
+              end)
+
+            assert_per_key_events(events_after_barrier(@name, actors.observer), removals)
+            assert Enum.sort(Group.local_entries(@name)) == survivors
+            assert :ok = TestCluster.assert_ets_consistent(@name)
+          end
+        end)
+      end
+    end
   end
 
   defp options(shards, buffer) do
@@ -143,16 +228,26 @@ defmodule Group.ReplicationPropertyTest do
     end)
   end
 
+  defp snapshot(kind, cluster, entries, shards) do
+    data = Enum.map(entries, fn {{key, pid}, meta} -> {key, pid, meta, 1_000} end)
+    {reg, pg} = if kind == :registry, do: {data, []}, else: {[], data}
+
+    for shard <- 0..(shards - 1) do
+      send(Replica.shard_name(@name, shard), {:cluster_state, cluster, reg, pg})
+      :sys.get_state(Replica.shard_name(@name, shard))
+    end
+  end
+
   defp assert_per_key_events(actual, expected) do
     group = fn events -> Enum.group_by(events, &{&1.cluster, &1.key}) end
     assert group.(actual) == group.(expected)
   end
 
-  defp assert_entries(entries, kind, cluster) do
+  defp assert_entries(entries, kind, cluster, survivors \\ []) do
     expected =
       Enum.map(entries, fn {{key, pid}, meta} -> {kind, cluster, key, pid, meta} end)
 
-    assert Enum.sort(Group.local_entries(@name)) == Enum.sort(expected)
+    assert Enum.sort(Group.local_entries(@name)) == Enum.sort(survivors ++ expected)
 
     for key <- @keys do
       members = for {{^key, pid}, meta} <- entries, do: {pid, meta}


### PR DESCRIPTION
## Problem

A disconnected named cluster can appear correctly empty even if queued replication was incorrectly applied and then purged. Index consistency and final-state checks alone miss the transient lifecycle events, while stale batches and snapshots can also repopulate a cluster after it has been left.

## Fix

Add generated scenarios for both registry and PG lanes that prove operations are buffered before disconnect. Require the disconnect path and subsequent batch/snapshot replay to leave the cluster empty without emitting apply-then-purge events.

Vary shard counts, receiver buffers, metadata, and reconnect cycles. Reconnected clusters must accept fresh snapshots, and entries using the same key in the default and another named cluster must survive throughout.

## Supporting information

Stacked on #10, following #8. This PR adds only cluster-isolation properties and their snapshot helper, reusing the fixture and history oracle from the preceding PR.

Signals are deliberately delivered to the receiver while owner processes remain alive. This isolates membership gating from network lifecycle behavior; production behavior is unchanged.
