### PR TITLE
Check cluster lease policy across generated local interests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,7 +6,7 @@
 mix test                           # all tests
 mix test test/group_test.exs       # local only
 mix test test/group_property_test.exs # local model properties
-mix test test/replication_property_test.exs # receiver protocol properties
+mix test test/replication_property_test.exs test/cluster_lease_property_test.exs
 mix test test/distributed_test.exs # distributed only
 ```
 
@@ -17,6 +17,7 @@ mix test test/distributed_test.exs # distributed only
 | `group_test.exs` | Single-node: register/unregister, join/leave, members, monitor/demonitor, named clusters, concurrent operations |
 | `group_property_test.exs` | StreamData local command histories checked against an independent map/set model |
 | `replication_property_test.exs` | Generated receiver batch boundaries, buffered/snapshot cluster isolation, and local-write fairness |
+| `cluster_lease_property_test.exs` | Generated TTL interest combinations, removal order, no-refresh connects, and reconnects |
 | `distributed_test.exs` | Multi-node: replication, peer discovery, node disconnect cleanup, partition healing, conflict resolution, event ordering, rolling restarts |
 
 ## Local model properties
@@ -59,13 +60,13 @@ mix test test/group_property_test.exs --seed 12345
 
 StreamData reports the shrunk command sequence. Promote discovered failures to
 focused regression tests. A seed reproduces generation, not BEAM scheduling.
-The local model deliberately settles between commands. Receiver buffering and
-fairness are covered separately below, without growing the command model into a
-scheduler or transport simulator.
+The local model deliberately settles between commands. Receiver buffering, TTL,
+and fairness are covered separately below, without growing the command model
+into a scheduler or transport simulator.
 If the model grows into a substantial state-machine framework, evaluate
 PropCheck/PropEr rather than implementing that framework here.
 
-## Targeted protocol properties
+## Targeted protocol and lease properties
 
 `replication_property_test.exs` exercises both registry and PG receiver lanes:
 
@@ -91,6 +92,20 @@ keys retain one owner, leaving owner-conflict resolution to separate scenarios.
 The distributed suite remains necessary for real peer lifecycle and transport
 behavior. These properties do not claim reproducible network races or fairness
 under an infinite stream of control messages.
+
+`cluster_lease_property_test.exs` generates registry, PG, and monitor interest
+combinations across the leased, default, and another named cluster, then varies
+the removal order. Each forced expiry must extend exactly one TTL interval while
+cluster-local interest remains and disconnect once it is gone. Other clusters'
+interest must survive without keeping the leased cluster alive. It also checks
+that repeated connected calls cannot refresh an existing lease or add a lease
+to a plain connection, while a disconnected cluster can acquire a new lease.
+Runs 100 examples with varied shard counts.
+
+Lease deadlines are deliberately moved in ETS and the real lease manager is
+forced to sweep via the existing helper. Long TTLs prevent ordinary timer expiry
+from racing the scenario; a distinct future deadline makes accidental refreshes
+visible even within one clock tick. This checks expiry policy, not timer accuracy.
 
 `Group.PropertyFixture` owns the Group supervisor, owners, and a mailbox-preserving
 observer per example/shrink attempt. It tears them down in `after`, stops

--- a/test/cluster_lease_property_test.exs
+++ b/test/cluster_lease_property_test.exs
@@ -1,0 +1,139 @@
+defmodule Group.ClusterLeasePropertyTest do
+  use ExUnit.Case, async: false
+  use ExUnitProperties
+
+  import Group.PropertyFixture
+  alias Group.Replica.Data
+  alias Group.TestCluster
+
+  @name :lease_property
+  @target "leased"
+  @other "other"
+  @key "interest/key"
+
+  property "expiry follows remaining cluster-local interest, not connected connect calls" do
+    check all(
+            shards <- member_of([1, 2, 4]),
+            ttl <- integer(60_000..120_000),
+            repeated_ttls <- list_of(integer(1..240_000), min_length: 1, max_length: 5),
+            interests <-
+              map(
+                list_of(
+                  tuple(
+                    {member_of([@target, @other, nil]), member_of([:registry, :pg, :monitor])}
+                  ),
+                  max_length: 18
+                ),
+                &Enum.uniq/1
+              ),
+            max_runs: 100
+          ) do
+      with_group(@name, [shards: shards, log: false], fn actors ->
+        owner = actors[0]
+        assert :ok = Group.connect(@name, @target, ttl: ttl)
+        assert :ok = Group.connect(@name, @other)
+        manager = Group.ClusterLease.lease_name(@name)
+        :sys.get_state(manager)
+
+        assert {^ttl, deadline} = Data.cluster_lease(@name, @target)
+        # Make any refresh observable even when multiple calls share a clock tick.
+        sentinel = deadline + 3_600_000
+        Data.put_cluster_lease(@name, @target, ttl, sentinel)
+
+        for repeated_ttl <- [ttl | repeated_ttls] do
+          assert :ok = Group.connect(@name, @target, ttl: repeated_ttl)
+          assert Data.cluster_lease(@name, @target) == {ttl, sentinel}
+          assert :ok = Group.connect(@name, @other, ttl: repeated_ttl)
+          assert Data.cluster_lease(@name, @other) == nil
+        end
+
+        for interest <- interests, do: add_interest(owner, interest)
+        sweep_and_assert(interests, ttl, owner)
+
+        # Generated list order also varies removal order. Sweep after each
+        # removal, checking combinations rather than one interest type at a time.
+        Enum.reduce(interests, interests, fn interest, remaining ->
+          remove_interest(owner, interest)
+          remaining = List.delete(remaining, interest)
+
+          if Group.connected?(@name, @target) do
+            sweep_and_assert(remaining, ttl, owner)
+          else
+            assert Data.cluster_lease(@name, @target) == nil
+            assert_interests(remaining, owner)
+          end
+
+          remaining
+        end)
+
+        refute Group.connected?(@name, @target)
+        assert Data.cluster_lease(@name, @target) == nil
+
+        # A disconnected cluster may acquire a new lease; a still-connected
+        # plain cluster above may not. Reconnect must not resurrect old interest.
+        new_ttl = List.last(repeated_ttls) + 60_000
+        assert :ok = Group.connect(@name, @target, ttl: new_ttl)
+        assert {^new_ttl, _} = Data.cluster_lease(@name, @target)
+        :sys.get_state(manager)
+        sweep_and_assert([], new_ttl, owner)
+      end)
+    end
+  end
+
+  defp sweep_and_assert(interests, ttl, owner) do
+    before_sweep = System.monotonic_time(:millisecond)
+    TestCluster.do_expire_cluster_lease_and_force_sweep(@name, @target)
+    after_sweep = System.monotonic_time(:millisecond)
+    active? = Enum.any?(interests, fn {cluster, _kind} -> cluster == @target end)
+
+    assert Group.connected?(@name, @target) == active?
+
+    if active? do
+      assert {^ttl, deadline} = Data.cluster_lease(@name, @target)
+      assert deadline >= before_sweep + ttl
+      assert deadline <= after_sweep + ttl
+    else
+      assert Data.cluster_lease(@name, @target) == nil
+    end
+
+    assert_interests(interests, owner)
+    assert :ok = TestCluster.assert_ets_consistent(@name)
+  end
+
+  defp assert_interests(interests, owner) do
+    # Interest in nil/other must neither keep the target alive nor be purged.
+    assert Group.connected?(@name, @other)
+
+    for cluster <- [nil, @target, @other] do
+      registry = if {cluster, :registry} in interests, do: {owner, %{}}, else: nil
+      pg = if {cluster, :pg} in interests, do: [{owner, %{}}], else: []
+      assert Group.lookup(@name, @key, cluster: cluster) == registry
+      assert Group.members(@name, @key, cluster: cluster) == pg
+
+      subscriptions = Registry.keys(Group.registry_name(@name), owner)
+      assert {@name, cluster, :all} in subscriptions == {cluster, :monitor} in interests
+    end
+  end
+
+  defp add_interest(owner, {cluster, kind}) do
+    assert :ok =
+             in_process(owner, fn ->
+               case kind do
+                 :registry -> Group.register(@name, @key, %{}, cluster: cluster)
+                 :pg -> Group.join(@name, @key, %{}, cluster: cluster)
+                 :monitor -> Group.monitor(@name, :all, cluster: cluster)
+               end
+             end)
+  end
+
+  defp remove_interest(owner, {cluster, kind}) do
+    assert :ok =
+             in_process(owner, fn ->
+               case kind do
+                 :registry -> Group.unregister(@name, @key, cluster: cluster)
+                 :pg -> Group.leave(@name, @key, cluster: cluster)
+                 :monitor -> Group.demonitor(@name, :all, cluster: cluster)
+               end
+             end)
+  end
+end


### PR DESCRIPTION
## Problem

Lease expiry depends on combinations of local registry entries, PG memberships, and monitor subscriptions. Covering one interest type at a time leaves gaps around removal order, interest in other clusters, connected-call no-ops, and reconnects.

## Fix

Generate combinations of registry, PG, and monitor interest across the leased, default, and another named cluster. Force expiry after each removal and require exactly one TTL extension while cluster-local interest remains, followed by disconnect once it is gone. Other clusters' interest must survive without keeping the leased cluster alive.

Also check that connected calls neither refresh an existing lease nor add a lease to a plain connection, while a disconnected cluster can acquire a new lease. A distinct future deadline makes accidental refreshes observable even within one clock tick.

## Supporting information

Stacked on #12, completing the #8 → #10 → #11 → #12 → TTL chain. #7 remains independent.

The scenarios use fresh fixtures for every example and shrink attempt, explicitly move lease deadlines, and drive the real lease manager through its existing forced-sweep helper. Long TTLs isolate expiry policy from timer scheduling; timer accuracy and production behavior are unchanged.
