### PR TITLE
Check acknowledged metadata in terminal Jepsen views

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule Group.MixProject do
 
   defp aliases do
     [
-      test: ["test", "cmd test/jepsen/checker.sh"],
+      test: ["test", "cmd test/jepsen/checker.sh", "cmd test/jepsen/lein.sh test :capture"],
       "test.soak": [
         # Run the PR gate in a child VM. test_helper starts distribution, and
         # keeping that VM alive for the following `cmd` phases can retain a

--- a/test/jepsen/README.md
+++ b/test/jepsen/README.md
@@ -32,7 +32,8 @@ The replica lane is selectable without changing the workload or checker:
 After faults stop, every surviving node reconnects and the harness takes two
 terminal snapshots. The independent checker requires:
 
-- exact, identical public registry and PG views on every survivor;
+- exact, identical public registry and PG metadata on every survivor, including
+  each revision acknowledged by its owner;
 - every live owner claim to be visible, and no dead owner token to remain;
 - deterministic resolution of registry conflicts with no unexpected owner
   deaths;
@@ -135,7 +136,16 @@ test/jepsen/checker.sh
 ```
 
 At the repository root, `mix test` runs this pure checker after the complete
-ExUnit, StreamData, and deterministic-chaos suite. `mix test.soak` runs that
+ExUnit, StreamData, and deterministic-chaos suite, followed by executable
+capture qualification (`test/jepsen/lein.sh test :capture`, requiring Elixir).
+The capture qualification mutates real owners repeatedly, corrupts materialized
+metadata while preserving internal index consistency, and passes the real
+snapshot EDN to the independent checker. Public values retain metadata maps
+rather than only tokens; node/boot/owner/incarnation tokens still identify owner
+lifetimes without exporting raw PIDs. Old token-only histories are intentionally
+not accepted as exact metadata evidence.
+
+`mix test.soak` runs that
 same PR gate, the complete mutation/live-checker qualification, and then
 `campaign.sh`. Chaos/mixed uses a sender/repair buffer of 32 and requires
 evidence that one repaired delta run contained at least two records; all other

--- a/test/jepsen/metadata_capture.exs
+++ b/test/jepsen/metadata_capture.exs
@@ -1,0 +1,76 @@
+System.put_env("GROUP_JEPSEN_LIBRARY", "1")
+Code.require_file("node.exs", __DIR__)
+
+alias Group.Jepsen.{Driver, EDN, Snapshot}
+alias Group.Replica.Data
+
+{:ok, _} = Group.Jepsen.Transport.Stats.start_link([])
+
+{:ok, _} =
+  Group.start_link(
+    name: :jepsen_group,
+    shards: 1,
+    log: false,
+    resolve_registry_conflict: {Group.Jepsen.ConflictResolver, :resolve, []}
+  )
+
+{:ok, _} = Group.Jepsen.Driver.Supervisor.start_link(node_id: "n1", boot_id: "capture")
+
+for revision <- 1..2, operation <- [:register, :join] do
+  %{status: :ok} = Driver.mutate(operation, "owner", nil, 0, revision)
+end
+
+capture = fn -> Snapshot.capture("n1", "capture", 1, [], []).snapshot end
+healthy = capture.()
+[owner] = healthy.owners
+expected = %{token: owner.token, revision: 2}
+^expected = healthy.registry["root"][0]
+[^expected] = healthy.pg["root"][0]
+[%{revision: 2}] = owner.registrations
+[%{revision: 2}] = owner.memberships
+
+# Corrupt all materialized indexes coherently: the old internal projection
+# invariant remains healthy, so only the independent owner/public comparison
+# can catch lost, missing or wrong acknowledged metadata.
+tables = [
+  Data.reg_by_key_table(:jepsen_group, 0),
+  Data.reg_by_pid_table(:jepsen_group, 0),
+  Data.reg_claim_by_key_table(:jepsen_group, 0),
+  Data.reg_claim_by_pid_table(:jepsen_group, 0),
+  Data.pg_by_key_table(:jepsen_group, 0),
+  Data.pg_by_pid_table(:jepsen_group, 0)
+]
+
+originals = Map.new(tables, &{&1, :ets.tab2list(&1)})
+
+corruptions =
+  for meta <- [
+        %{token: owner.token, revision: 1},
+        %{token: owner.token},
+        %{token: owner.token, revision: "2"},
+        %{token: "wrong-owner", revision: 2},
+        %{token: owner.token, revision: 2, extra: true}
+      ] do
+    Enum.each(originals, fn {table, rows} ->
+      changed =
+        Enum.map(rows, fn row ->
+          row
+          |> Tuple.to_list()
+          |> Enum.map(fn value -> if value == expected, do: meta, else: value end)
+          |> List.to_tuple()
+        end)
+
+      :ets.insert(table, changed)
+    end)
+
+    result = capture.()
+    true = result.internal.healthy
+    result
+  end
+
+Enum.each(originals, fn {table, rows} -> :ets.insert(table, rows) end)
+%{status: :ok} = Driver.kill("owner")
+%{status: :ok, owner: reincarnated} = Driver.mutate(:join, "owner", nil, 0, 2)
+false = reincarnated.token == owner.token
+
+File.write!(hd(System.argv()), EDN.encode(%{healthy: healthy, corruptions: corruptions}))

--- a/test/jepsen/node.exs
+++ b/test/jepsen/node.exs
@@ -1240,7 +1240,7 @@ defmodule Group.Jepsen.Snapshot do
             value =
               case Group.lookup(:jepsen_group, registry_key(key), cluster_opts(cluster)) do
                 nil -> nil
-                {_pid, %{token: token}} -> token
+                {_pid, %{token: _token} = meta} -> meta
                 {_pid, other} -> "INVALID:#{inspect(other)}"
               end
 
@@ -1258,7 +1258,7 @@ defmodule Group.Jepsen.Snapshot do
               :jepsen_group
               |> Group.members(pg_key(key), cluster_opts(cluster))
               |> Enum.map(fn
-                {_pid, %{token: token}} -> token
+                {_pid, %{token: _token} = meta} -> meta
                 {_pid, other} -> "INVALID:#{inspect(other)}"
               end)
               |> Enum.sort()
@@ -1565,4 +1565,6 @@ defmodule Group.Jepsen.Main do
   end
 end
 
-Group.Jepsen.Main.run(System.argv())
+unless System.get_env("GROUP_JEPSEN_LIBRARY") == "1" do
+  Group.Jepsen.Main.run(System.argv())
+end

--- a/test/jepsen/project.clj
+++ b/test/jepsen/project.clj
@@ -4,5 +4,7 @@
   :license {:name "MIT"}
   :dependencies [[org.clojure/clojure "1.12.4"]
                  [jepsen "0.3.13"]]
+  :test-selectors {:default (complement :capture)
+                   :capture :capture}
   :main group.jepsen.core
   :jvm-opts ["-Xmx4g" "-Djava.awt.headless=true" "-server"])

--- a/test/jepsen/src/group/jepsen/model.clj
+++ b/test/jepsen/src/group/jepsen/model.clj
@@ -40,9 +40,10 @@
   (let [owners (->> snapshots vals (mapcat :owners) (map (juxt :token identity)) (into {}))
         registry-candidates
         (reduce (fn [by-key [_ owner]]
-                  (reduce (fn [entries {:keys [cluster key]}]
+                  (reduce (fn [entries {:keys [cluster key revision]}]
                             (update entries [(or cluster "root") key]
-                                    (fnil conj #{}) (:token owner)))
+                                    (fnil conj #{}) {:token (:token owner)
+                                                     :revision revision}))
                           by-key
                           (owner-entries owner :registrations)))
                 {}
@@ -55,9 +56,10 @@
                 registry-candidates)
         pg
         (reduce (fn [view [_ owner]]
-                  (reduce (fn [entries {:keys [cluster key]}]
+                  (reduce (fn [entries {:keys [cluster key revision]}]
                             (update-in entries [(or cluster "root") key]
-                                       (fnil conj #{}) (:token owner)))
+                                       (fnil conj #{}) {:token (:token owner)
+                                                        :revision revision}))
                           view
                           (owner-entries owner :memberships)))
                 (empty-view test #{})
@@ -176,11 +178,12 @@
                                      (concat
                                        (->> registry vals (mapcat vals) (remove nil?))
                                        (->> pg vals (mapcat vals) (mapcat identity)))))
+                           (map :token)
                            set)
         expected-tokens
         (set/union
-          (->> (:registry expected) vals (mapcat vals) (remove nil?) set)
-          (->> (:pg expected) vals (mapcat vals) (mapcat identity) set))
+          (->> (:registry expected) vals (mapcat vals) (remove nil?) (map :token) set)
+          (->> (:pg expected) vals (mapcat vals) (mapcat identity) (map :token) set))
         orphaned (set/difference actual-tokens live-tokens)
         missing-live (set/difference expected-tokens actual-tokens)
         latencies (operation-latencies history)

--- a/test/jepsen/test/group/jepsen/metadata_capture_test.clj
+++ b/test/jepsen/test/group/jepsen/metadata_capture_test.clj
@@ -1,0 +1,30 @@
+(ns group.jepsen.metadata-capture-test
+  (:require [clojure.edn :as edn]
+            [clojure.java.shell :as shell]
+            [clojure.test :refer :all]
+            [group.jepsen.model :as model]))
+
+(def capture-test
+  {:nodes ["n1"] :key-count 1 :clusters [] :transport "distribution"
+   :terminal-snapshots-per-node 1 :required-transport-events #{}})
+
+(defn analyze-snapshot [snapshot]
+  (model/analyze capture-test
+                 [{:index 0 :process 0 :type :ok :f :snapshot :value snapshot}]))
+
+(deftest ^:capture captures-acknowledged-metadata-through-the-real-edn-boundary
+  (let [output (java.io.File/createTempFile "group-metadata-" ".edn")]
+    (try
+      (let [run (shell/sh "env" "ERL_FLAGS=+S 2:2" "MIX_ENV=test" "mix" "run"
+                          "test/jepsen/metadata_capture.exs" (.getPath output)
+                          :dir "../..")]
+        (is (= 0 (:exit run)) (str (:out run) (:err run)))
+        (when (zero? (:exit run))
+          (let [{:keys [healthy corruptions]} (edn/read-string (slurp output))]
+            (is (:valid? (analyze-snapshot healthy)))
+            (doseq [snapshot corruptions]
+              (let [result (analyze-snapshot snapshot)]
+                (is (true? (get-in snapshot [:internal :healthy])))
+                (is (false? (:valid? result)))
+                (is (seq (:mismatched-views result))))))))
+      (finally (.delete output)))))

--- a/test/jepsen/test/group/jepsen/model_test.clj
+++ b/test/jepsen/test/group/jepsen/model_test.clj
@@ -63,11 +63,29 @@
 (defn with-unexpected-death [op token]
   (assoc-in op [:value :unexpected-deaths] [{:token token, :reason ":boom"}]))
 
+(deftest compares-each-owner-recorded-revision-exactly
+  (let [owners [(owner "a" [(registration nil 0 2)] [(membership nil 0 3)])]
+        registry (assoc-in (empty-registry) ["root" 0] {:token "a" :revision 2})
+        pg (assoc-in (empty-pg) ["root" 0] [{:token "a" :revision 3}])
+        history (mapv #(snapshot-op % (str "n" %) (if (= 1 %) owners [])
+                                    registry pg) [1 2 3])]
+    (is (:valid? (model/analyze test-map history)))
+    (doseq [field [:registry :pg]
+            bad [{:token "a" :revision 1} {:token "a"} {:token "b" :revision 2}
+                 {:token "a" :revision "2"} nil]]
+      (let [changed (assoc-in history [1 :value field "root" 0]
+                             (if (= field :pg) [bad] bad))
+            result (model/analyze test-map changed)]
+        (is (false? (:valid? result)))
+        (is (contains? (:mismatched-views result) "n2"))))))
+
 (deftest accepts-an-exact-converged-multi-cluster-view
   (let [owners [(owner "a" [(registration nil 0 1) (registration "red" 1 2)] [])
                 (owner "b" [] [(membership nil 1 2) (membership "red" 0 3)])]
-        registry (public-view {0 "a", 1 nil} {0 nil, 1 "a"})
-        pg (public-view {0 [], 1 ["b"]} {0 ["b"], 1 []})
+        registry (public-view {0 {:token "a" :revision 1}, 1 nil}
+                              {0 nil, 1 {:token "a" :revision 2}})
+        pg (public-view {0 [], 1 [{:token "b" :revision 2}]}
+                        {0 [{:token "b" :revision 3}], 1 []})
         history [(snapshot-op 1 "n1" owners registry pg)
                  (snapshot-op 2 "n2" [] registry pg)
                  (snapshot-op 3 "n3" [] registry pg)]]
@@ -96,7 +114,7 @@
 
 (deftest rejects-zombies-missing-live-owners-and-divergence
   (let [live (owner "live" [(registration nil 0 1)] [])
-        stale-registry (assoc-in (empty-registry) ["root" 0] "dead")
+        stale-registry (assoc-in (empty-registry) ["root" 0] {:token "dead" :revision 1})
         result (model/analyze
                  test-map
                  [(snapshot-op 1 "n1" [live] stale-registry (empty-pg))
@@ -116,7 +134,8 @@
                  (snapshot-op 3 "n3" [] registry (empty-pg))]
         result (model/analyze test-map history)]
     (is (false? (:valid? result)))
-    (is (= {["root" 0] #{"a" "b"}} (:live-registry-conflicts result)))))
+    (is (= {["root" 0] #{{:token "a" :revision 1} {:token "b" :revision 2}}}
+           (:live-registry-conflicts result)))))
 
 (deftest rejects-an-unexpected-owner-death-even-after-cleanup
   (let [result (model/analyze


### PR DESCRIPTION
## Problem

Terminal snapshots reduced registry and process-group entries to owner tokens. A receiver could retain revision 1 after its owner acknowledged revision 2 and still match the independent model, even when every internal index agreed with the stale value.

## Fix

Carry the full public metadata map through snapshot EDN and construct the expected registry and PG values from each owner's acknowledged revision. Compare metadata exactly while retaining incarnation-scoped tokens for lifecycle and orphan detection.

Executable capture qualification repeatedly updates real owners, injects stale, missing, wrong-type, wrong-owner and extra metadata into consistent materialized indexes, and feeds actual captured EDN to the independent checker. The capture qualification is part of the normal Mix gate and remains separate from the Java-only pure checker.

## Supporting information

This changes the terminal evidence schema: public values are metadata maps instead of token strings. Token-only historical captures cannot qualify as exact metadata evidence. Owner identity remains scoped by node, boot, logical owner and incarnation; raw PIDs are not exported.
